### PR TITLE
Dj/code coverage artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,23 +67,15 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
-      - name: Upload coverage report as artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage
-          path: coverage.xml
-          overwrite: true
-
       - name: Add Coverage Report to GitHub Pages
-        if: github.event_name == 'pull_request'
+        if: github.event.pull_request.merged == true && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           ls
           mkdir -p public
           mv code-coverage-results.md public/
 
       - name: Deploy Coverage Report to GitHub Pages
-        if: github.event_name == 'pull_request'
+        if: github.event.pull_request.merged == true && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR should run test coverage as normal, but when merged to `main` it should publish the coverage artifact to gh pages