### PR TITLE
chore: fix-ish `make helm`, add `helm-docs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	@$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -129,6 +129,10 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	@if [ -d "config/crd" ]; then \
+		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+	fi
+	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
@@ -168,6 +172,8 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+HELMIFY ?= $(LOCALBIN)/helmify
+HELM_DOCS = $(LOCALBIN)/helm-docs
 UNAME := $(shell uname -s)
 
 ## Tool Versions
@@ -175,6 +181,8 @@ KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.63.4
+HELMIFY_VERSION ?= v0.4.17
+HELM_DOCS_VERSION ?= v1.14.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -196,6 +204,16 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
+.PHONY: helmify
+helmify: $(HELMIFY) ## Download helmify locally if necessary.
+$(HELMIFY): $(LOCALBIN)
+	$(call go-install-tool,$(HELMIFY),github.com/arttor/helmify/cmd/helmify,$(HELMIFY_VERSION))
+
+.PHONY: helm-docs
+helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
+	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,$(HELM_DOCS_VERSION))
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed
@@ -212,12 +230,14 @@ mv $(1) $(1)-$(3) ;\
 ln -sf $(1)-$(3) $(1)
 endef
 
-HELMIFY ?= $(LOCALBIN)/helmify
-
-.PHONY: helmify
-helmify: $(HELMIFY) ## Download helmify locally if necessary.
-$(HELMIFY): $(LOCALBIN)
-	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
-
-helm: manifests kustomize helmify
-	$(KUSTOMIZE) build config/default | $(HELMIFY) deployment
+helm: manifests kustomize helmify helm-docs
+	@$(KUSTOMIZE) build config/default | $(HELMIFY) deployment
+	@for file in deployment/templates/serving-cert.yaml deployment/templates/selfsigned-issuer.yaml; do \
+	  tmp_file=$$(mktemp); \
+	  printf "{{- if .Values.webhooks.certManager.enabled }}\n" > "$$tmp_file"; \
+	  cat "$$file" >> "$$tmp_file"; \
+	  printf "\n{{- end }}" >> "$$tmp_file"; \
+	  mv "$$tmp_file" "$$file"; \
+	done
+	@printf "webhooks:\n  certManager:\n    enabled: false\n  autoGenerateCert:\n    enabled: true\n    certValidDays: 3650\n" >> deployment/values.yaml
+	@$(HELM_DOCS) --skip-version-footer deployment -f values.yaml -l warning

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,8 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         env:
+          - name: VALKEY_AUDIT_STREAM_EXPIRY_MS
+            value: "2592000000"
           - name: VALKEY_ENDPOINT
             valueFrom:
               secretKeyRef:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,38 @@
+# mdai-operator
+
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.5](https://img.shields.io/badge/AppVersion-0.1.5-informational?style=flat-square)
+
+MDAI Operator Helm Chart
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controllerManager.manager.args[0] | string | `"--metrics-bind-address=:8443"` |  |
+| controllerManager.manager.args[1] | string | `"--leader-elect=false"` |  |
+| controllerManager.manager.args[2] | string | `"--health-probe-bind-address=:8081"` |  |
+| controllerManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| controllerManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| controllerManager.manager.env.valkeyAuditStreamExpiryMs | string | `"2592000000"` |  |
+| controllerManager.manager.image.repository | string | `"public.ecr.aws/p3k6k6h3/mdai-operator"` |  |
+| controllerManager.manager.image.tag | string | `"0.1.5"` |  |
+| controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
+| controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
+| controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |
+| controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| controllerManager.replicas | int | `1` |  |
+| controllerManager.serviceAccount.annotations | object | `{}` |  |
+| kubernetesClusterDomain | string | `"cluster.local"` |  |
+| metricsService.ports[0].name | string | `"https"` |  |
+| metricsService.ports[0].port | int | `8443` |  |
+| metricsService.ports[0].protocol | string | `"TCP"` |  |
+| metricsService.ports[0].targetPort | int | `8443` |  |
+| metricsService.type | string | `"ClusterIP"` |  |
+| webhookService.ports[0].port | int | `443` |  |
+| webhookService.ports[0].protocol | string | `"TCP"` |  |
+| webhookService.ports[0].targetPort | int | `9443` |  |
+| webhookService.type | string | `"ClusterIP"` |  |
+| webhooks.autoGenerateCert.certValidDays | int | `3650` |  |
+| webhooks.autoGenerateCert.enabled | bool | `true` |  |
+| webhooks.certManager.enabled | bool | `false` |  |

--- a/deployment/templates/deployment.yaml
+++ b/deployment/templates/deployment.yaml
@@ -25,7 +25,8 @@ spec:
         - /manager
         env:
         - name: VALKEY_AUDIT_STREAM_EXPIRY_MS
-          value: "{{ .Values.auditStreamExpiryMs }}"
+          value: {{ quote .Values.controllerManager.manager.env.valkeyAuditStreamExpiryMs
+            }}
         - name: VALKEY_ENDPOINT
           valueFrom:
             secretKeyRef:

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -9,6 +9,8 @@ controllerManager:
       capabilities:
         drop:
         - ALL
+    env:
+      valkeyAuditStreamExpiryMs: "2592000000"
     image:
       repository: public.ecr.aws/p3k6k6h3/mdai-operator
       tag: 0.1.5


### PR DESCRIPTION
 * make `make helm` have fewer diffs
 * add `helm-docs` to `make helm`
 * `valkeyAuditStreamExpiryMs` has a default at the `helm` level (matches code), can be modified via `--set controllerManager.manager.env.valkeyAuditStreamExpiryMs=60000`
 * changed how `helmify` is installed (if needed)
 * silenced some `Makefile` actions