### PR TITLE
chore: do not put CRD in `templates` but rather `crds` and publish it to `gh-pages` branch so it can be used in `kubectl apply` to upgrade

### DIFF
--- a/.github/workflows/publish-crds.yaml
+++ b/.github/workflows/publish-crds.yaml
@@ -1,0 +1,34 @@
+name: Publish CRDs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-crds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Copy CRDs to publish folder
+        run: |
+          mkdir -p gh-pages
+          cp -r deployment/crds/* gh-pages/
+
+      - name: Deploy to gh-pages branch
+        run: |
+          git fetch origin gh-pages || true
+          git checkout --orphan gh-pages
+          git rm -rf .
+          cp -r gh-pages/* .
+          touch .nojekyll
+          git add .
+          git commit -m "Publish CRDs from deployment/crds"
+          git push -f origin gh-pages

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ endef
 .PHONY: helm-update
 helm-update: manifests kustomize helmify helm-docs  helm-values-schema-json-plugin
 	@pushd config/manager && $(KUSTOMIZE) edit set image controller=public.ecr.aws/p3k6k6h3/mdai-operator:${VERSION} && popd
-	@$(KUSTOMIZE) build config/default | $(HELMIFY) deployment
+	@$(KUSTOMIZE) build config/default | $(HELMIFY) -crd-dir deployment
 	@m4 -D__VERSION__="${VERSION}" deployment/Chart.yaml.m4 > deployment/Chart.yaml
 	@$(HELM_DOCS) --skip-version-footer deployment -f values.yaml -l warning
 	@helm schema -input deployment/values.yaml -output deployment/values.schema.json > /dev/null 2>&1

--- a/deployment/crds/mdaihub-crd.yaml
+++ b/deployment/crds/mdaihub-crd.yaml
@@ -1,11 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mdaihubs.hub.mydecisive.ai
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  labels:
-  {{- include "deployment.labels" . | nindent 4 }}
+  name: mdaihubs.hub.mydecisive.ai
 spec:
   group: hub.mydecisive.ai
   names:
@@ -44,8 +42,9 @@ spec:
                 description: kubebuilder:validation:Optional
                 properties:
                   evaluation_interval:
-                    description: EvaluationInterval Specify the interval at which all
-                      evaluations within this hub are assessed in the Prometheus infrastructure.
+                    description: EvaluationInterval Specify the interval at which
+                      all evaluations within this hub are assessed in the Prometheus
+                      infrastructure.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
@@ -59,8 +58,8 @@ spec:
                       description: Expr A valid PromQL query expression
                       x-kubernetes-int-or-string: true
                     for:
-                      description: For Alerts are considered firing once they have been
-                        returned for this long.
+                      description: For Alerts are considered firing once they have
+                        been returned for this long.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     keep_firing_for:
@@ -80,15 +79,16 @@ spec:
                         on the state of the evaluation
                       properties:
                         firing:
-                          description: Firing Action performed when the Prometheus Alert
-                            status changes to "firing"
+                          description: Firing Action performed when the Prometheus
+                            Alert status changes to "firing"
                           properties:
                             variableUpdate:
                               description: VariableUpdate Modify the value of a managed
                                 variable.
                               properties:
                                 operation:
-                                  description: Operation how the variable will be updated
+                                  description: Operation how the variable will be
+                                    updated
                                   enum:
                                   - mdai/add_element
                                   - mdai/remove_element
@@ -113,7 +113,8 @@ spec:
                                 variable.
                               properties:
                                 operation:
-                                  description: Operation how the variable will be updated
+                                  description: Operation how the variable will be
+                                    updated
                                   enum:
                                   - mdai/add_element
                                   - mdai/remove_element
@@ -175,10 +176,10 @@ spec:
                           description: |-
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
-  
+
                             This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
-  
+
                             This field is immutable. It can only be set for containers.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
@@ -278,14 +279,14 @@ spec:
                       items:
                         properties:
                           name:
-                            description: Name The environment variable name to be used
-                              to access the variable's value.
+                            description: Name The environment variable name to be
+                              used to access the variable's value.
                             minLength: 1
                             type: string
                           transformer:
-                            description: Transformer The transformation applied to the
-                              value of the variable before it is assigned as an environment
-                              variable.
+                            description: Transformer The transformation applied to
+                              the value of the variable before it is assigned as an
+                              environment variable.
                             properties:
                               join:
                                 description: Join For use with "set" or "array" type
@@ -293,8 +294,9 @@ spec:
                                   a string.
                                 properties:
                                   delimiter:
-                                    description: Delimiter The delimiter inserted between
-                                      each item in the collection during the Join
+                                    description: Delimiter The delimiter inserted
+                                      between each item in the collection during the
+                                      Join
                                     type: string
                                 required:
                                 - delimiter
@@ -336,7 +338,8 @@ spec:
             description: MdaiHubStatus defines the observed state of MdaiHub.
             properties:
               conditions:
-                description: Conditions store the status conditions of the Cluster instances
+                description: Conditions store the status conditions of the Cluster
+                  instances
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -410,9 +413,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
* change `Makefile` to put CRD in `crds/` instead of `templates/`
* provide a GitHub Action to publish CRDs to `gh-pages` branch to allow them to be available via a URL to `kubectl apply` (for upgrade)

* will update `README.md` with URL to `kubectl apply` the CRD (`helm upgrade --install` will *install* the CRD but not upgrade. `--skip-crds` should make it not even install them)