### PR TITLE
feat: add `runID` to TelemetryValidation CRD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ go.work
 /deployment/values.schema.json
 
 cover.txt
+
+mdai-operator-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GO := CGO_ENABLED=0 GOTOOLCHAIN=$(GOTOOLCHAIN) go
 GO_TEST := $(GO) test -count=1
 
 # Image URL to use all building/pushing image targets
-IMG ?= public.ecr.aws/decisiveai/mdai-operator:${VERSION}
+IMG ?= ghcr.io/mydecisive/mdai-operator:${VERSION}
 
 CHART_PATH := deployment
 

--- a/api/v1/telemetryvalidation_types.go
+++ b/api/v1/telemetryvalidation_types.go
@@ -57,6 +57,11 @@ type TelemetryValidationSpec struct {
 	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled,omitempty"`
 
+	// RunID identifies a run of the TelemetryValidation. When omitted, the controller generates one and records it in
+	// status.runID.
+	// +optional
+	RunID string `json:"runID,omitempty"`
+
 	CollectorRef TelemetryValidationCollectorRef `json:"collectorRef"`
 
 	// +optional
@@ -82,6 +87,7 @@ type TelemetryValidationStatus struct {
 	ValidatorEndpoint    string `json:"validatorEndpoint,omitempty"`
 	ValidatorIngressPort int32  `json:"validatorIngressPort,omitempty"`
 	ObservedGeneration   int64  `json:"observedGeneration,omitempty"`
+	RunID                string `json:"runID,omitempty"`
 
 	// +optional
 	ActiveSignals []TelemetrySignal `json:"activeSignals,omitempty"`

--- a/config/crd/bases/hub.mydecisive.ai_telemetryvalidations.yaml
+++ b/config/crd/bases/hub.mydecisive.ai_telemetryvalidations.yaml
@@ -70,6 +70,11 @@ spec:
                   - matchExporterPrefixes
                   type: object
                 type: array
+              runID:
+                description: |-
+                  RunID identifies a run of the TelemetryValidation. When omitted, the controller generates one and records it in
+                  status.runID.
+                type: string
               shadowDebugExporterEnabled:
                 type: boolean
               signals:
@@ -170,6 +175,8 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              runID:
+                type: string
               shadowCollectorName:
                 type: string
               shadowServiceName:

--- a/deployment/templates/telemetryvalidation-crd.yaml
+++ b/deployment/templates/telemetryvalidation-crd.yaml
@@ -72,6 +72,11 @@ spec:
                   - matchExporterPrefixes
                   type: object
                 type: array
+              runID:
+                description: |-
+                  RunID identifies a run of the TelemetryValidation. When omitted, the controller generates one and records it in
+                  status.runID.
+                type: string
               shadowDebugExporterEnabled:
                 type: boolean
               signals:
@@ -172,6 +177,8 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              runID:
+                type: string
               shadowCollectorName:
                 type: string
               shadowServiceName:

--- a/internal/controller/telemetryvalidation_adapter.go
+++ b/internal/controller/telemetryvalidation_adapter.go
@@ -25,6 +25,7 @@ type TelemetryValidationAdapter struct {
 	validatorServiceName       string
 	resolvedValidatorEndpoint  string
 	validatorIngressPortStatus int32
+	resolvedRunID              string
 }
 
 func NewTelemetryValidationAdapter(
@@ -63,8 +64,33 @@ func (*TelemetryValidationAdapter) ensureStatusSetToDone(context.Context) (Opera
 	return ContinueProcessing()
 }
 
+func (c *TelemetryValidationAdapter) ensureRunIDResolved(ctx context.Context) (OperationResult, error) {
+	runID, shouldUpdateStatus, err := resolveTelemetryValidationRunID(c.validation)
+	if err != nil {
+		return ContinueWithError(err)
+	}
+	c.resolvedRunID = runID
+	c.validation.Status.RunID = runID
+
+	if !shouldUpdateStatus {
+		return ContinueProcessing()
+	}
+
+	metaCopy := c.validation.DeepCopy()
+	metaCopy.Status.RunID = runID
+	if err := c.reconciler.Status().Update(ctx, metaCopy); err != nil {
+		return ContinueWithError(err)
+	}
+	c.validation = metaCopy
+	return ContinueProcessing()
+}
+
 func (c *TelemetryValidationAdapter) ensureSynchronized(ctx context.Context) (OperationResult, error) {
-	validatorName, validatorServiceName, resolvedValidatorEndpoint, validatorIngressPort, err := c.reconciler.reconcileValidator(ctx, c.validation)
+	validatorName, validatorServiceName, resolvedValidatorEndpoint, validatorIngressPort, err := c.reconciler.reconcileValidator(
+		ctx,
+		c.validation,
+		c.resolvedRunID,
+	)
 	if err != nil {
 		return ContinueWithError(err)
 	}
@@ -81,6 +107,7 @@ func (c *TelemetryValidationAdapter) ensureSynchronized(ctx context.Context) (Op
 		c.validatorServiceName,
 		c.resolvedValidatorEndpoint,
 		c.validatorIngressPortStatus,
+		c.resolvedRunID,
 	)
 }
 

--- a/internal/controller/telemetryvalidation_controller.go
+++ b/internal/controller/telemetryvalidation_controller.go
@@ -2,9 +2,11 @@ package controller
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,25 +30,29 @@ type TelemetryValidationReconciler struct {
 }
 
 const (
-	correlationProcessorName               = "attributes/correlation_id"
-	correlationResourceProcessorName       = "resource/correlation_id"
-	correlationDDTagsProcessorName         = "transform/correlation_ddtags"
-	correlationMetricsProcessorName        = "transform/metrics_correlation_id"
-	correlationAttributeKey                = "correlation_id"
-	correlationHeaderFromCtxKey            = "metadata.x-correlation-id"
-	correlationDDTagKey                    = "correlation_id:"
-	setDDTagsOnlyStatement                 = `set(attributes["ddtags"], Concat(["%s", attributes["%s"]], "")) where attributes["%s"] != nil and attributes["ddtags"] == nil`
-	appendDDTagsStatement                  = `set(attributes["ddtags"], Concat([attributes["ddtags"], ",", "%s", attributes["%s"]], "")) where attributes["%s"] != nil and attributes["ddtags"] != nil`
-	setMetricCorrelationStatement          = `set(attributes["%s"], resource.attributes["%s"]) where attributes["%s"] == nil and resource.attributes["%s"] != nil`
-	deleteMetricDDTagsStatement            = `delete_key(attributes, "ddtags") where attributes["ddtags"] != nil`
-	deleteMetricTagsStatement              = `delete_key(attributes, "tags") where attributes["tags"] != nil`
-	defaultValidatorImage                  = "ghcr.io/mydecisive/mdai-fidelity-validator:0.1.0"
-	defaultValidatorPort             int32 = 18081
-	defaultValidatorReceiverPort     int32 = 8126
-	defaultValidatorReplicas         int32 = 1
-	telemetryValidationLabelKey            = "hub.mydecisive.ai/telemetry-validation"
-	telemetryValidationRoleShadow          = "telemetry-validation-shadow-collector"
-	telemetryValidationRoleValidator       = "telemetry-validation-validator"
+	correlationProcessorName                       = "attributes/correlation_id"
+	correlationResourceProcessorName               = "resource/correlation_id"
+	correlationDDTagsProcessorName                 = "transform/correlation_ddtags"
+	correlationMetricsProcessorName                = "transform/metrics_correlation_id"
+	correlationAttributeKey                        = "correlation_id"
+	correlationHeaderFromCtxKey                    = "metadata.x-correlation-id"
+	correlationDDTagKey                            = "correlation_id:"
+	setDDTagsOnlyStatement                         = `set(attributes["ddtags"], Concat(["%s", attributes["%s"]], "")) where attributes["%s"] != nil and attributes["ddtags"] == nil`
+	appendDDTagsStatement                          = `set(attributes["ddtags"], Concat([attributes["ddtags"], ",", "%s", attributes["%s"]], "")) where attributes["%s"] != nil and attributes["ddtags"] != nil`
+	setMetricCorrelationStatement                  = `set(attributes["%s"], resource.attributes["%s"]) where attributes["%s"] == nil and resource.attributes["%s"] != nil`
+	deleteMetricDDTagsStatement                    = `delete_key(attributes, "ddtags") where attributes["ddtags"] != nil`
+	deleteMetricTagsStatement                      = `delete_key(attributes, "tags") where attributes["tags"] != nil`
+	defaultValidatorImage                          = "ghcr.io/mydecisive/mdai-fidelity-validator:0.1.0"
+	defaultValidatorPort                     int32 = 18081
+	defaultValidatorReceiverPort             int32 = 8126
+	defaultValidatorReplicas                 int32 = 1
+	telemetryValidationLabelKey                    = "hub.mydecisive.ai/telemetry-validation"
+	telemetryValidationRunIDAnnotationKey          = "hub.mydecisive.ai/telemetry-validation-run-id"
+	telemetryValidationRunIDMetricLabel            = "telemetry_validation_run_id"
+	telemetryValidationPrometheusSourceLabel       = "__meta_kubernetes_service_label_hub_mydecisive_ai_telemetry_validation"
+	telemetryValidationRunIDPrometheusSource       = "__meta_kubernetes_service_annotation_hub_mydecisive_ai_telemetry_validation_run_id"
+	telemetryValidationRoleShadow                  = "telemetry-validation-shadow-collector"
+	telemetryValidationRoleValidator               = "telemetry-validation-validator"
 )
 
 // +kubebuilder:rbac:groups=hub.mydecisive.ai,resources=telemetryvalidations,verbs=get;list;watch;create;update;patch;delete
@@ -88,6 +94,7 @@ func (*TelemetryValidationReconciler) ReconcileHandler(ctx context.Context, adap
 
 	operations := []ReconcileOperation{
 		telemetryValidationAdapter.ensureDeletionProcessed,
+		telemetryValidationAdapter.ensureRunIDResolved,
 		telemetryValidationAdapter.ensureStatusInitialized,
 		telemetryValidationAdapter.ensureFinalizerInitialized,
 		telemetryValidationAdapter.ensureSynchronized,
@@ -144,4 +151,38 @@ func mergeMaps(a, b map[string]string) map[string]string {
 	maps.Copy(out, a)
 	maps.Copy(out, b)
 	return out
+}
+
+func resolveTelemetryValidationRunID(validation *hubv1.TelemetryValidation) (string, bool, error) {
+	specified := strings.TrimSpace(validation.Spec.RunID)
+	if specified != "" {
+		return specified, specified != validation.Status.RunID, nil
+	}
+	if strings.TrimSpace(validation.Status.RunID) != "" {
+		return validation.Status.RunID, false, nil
+	}
+
+	generated, err := generateTelemetryValidationRunID()
+	if err != nil {
+		return "", false, err
+	}
+	return generated, true, nil
+}
+
+func generateTelemetryValidationRunID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate telemetry validation run id: %w", err)
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf(
+		"%08x-%04x-%04x-%04x-%012x",
+		b[0:4],
+		b[4:6],
+		b[6:8],
+		b[8:10],
+		b[10:16],
+	), nil
 }

--- a/internal/controller/telemetryvalidation_controller.go
+++ b/internal/controller/telemetryvalidation_controller.go
@@ -175,8 +175,8 @@ func generateTelemetryValidationRunID() (string, error) {
 		return "", fmt.Errorf("generate telemetry validation run id: %w", err)
 	}
 
-	b[6] = (b[6] & 0x0f) | 0x40
-	b[8] = (b[8] & 0x3f) | 0x80
+	b[6] = (b[6] & 0x0f) | 0x40 //nolint:mnd
+	b[8] = (b[8] & 0x3f) | 0x80 //nolint:mnd
 	return fmt.Sprintf(
 		"%08x-%04x-%04x-%04x-%012x",
 		b[0:4],

--- a/internal/controller/telemetryvalidation_run_id_test.go
+++ b/internal/controller/telemetryvalidation_run_id_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hubv1 "github.com/mydecisive/mdai-operator/api/v1"
+)
+
+func TestResolveTelemetryValidationRunID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		specRunID   string
+		statusRunID string
+		want        string
+		wantUpdate  bool
+	}{
+		{
+			name:        "uses specified run id",
+			specRunID:   "manual-run",
+			statusRunID: "",
+			want:        "manual-run",
+			wantUpdate:  true,
+		},
+		{
+			name:        "specified run id replaces status",
+			specRunID:   "manual-run-2",
+			statusRunID: "manual-run-1",
+			want:        "manual-run-2",
+			wantUpdate:  true,
+		},
+		{
+			name:        "reuses generated status run id",
+			statusRunID: "existing-generated",
+			want:        "existing-generated",
+			wantUpdate:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			validation := &hubv1.TelemetryValidation{
+				Spec: hubv1.TelemetryValidationSpec{
+					RunID: tt.specRunID,
+				},
+				Status: hubv1.TelemetryValidationStatus{
+					RunID: tt.statusRunID,
+				},
+			}
+
+			got, shouldUpdate, err := resolveTelemetryValidationRunID(validation)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantUpdate, shouldUpdate)
+		})
+	}
+}
+
+func TestGenerateTelemetryValidationRunID(t *testing.T) {
+	t.Parallel()
+
+	first, err := generateTelemetryValidationRunID()
+	require.NoError(t, err)
+	second, err := generateTelemetryValidationRunID()
+	require.NoError(t, err)
+
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, first)
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, second)
+	assert.NotEqual(t, first, second)
+}

--- a/internal/controller/telemetryvalidation_shadow.go
+++ b/internal/controller/telemetryvalidation_shadow.go
@@ -22,6 +22,7 @@ func (r *TelemetryValidationReconciler) reconcileShadowCollector(
 	validatorServiceName string,
 	resolvedValidatorEndpoint string,
 	validatorIngressPortStatus int32,
+	runID string,
 ) (OperationResult, error) {
 	log := logger.FromContext(ctx)
 
@@ -36,7 +37,14 @@ func (r *TelemetryValidationReconciler) reconcileShadowCollector(
 
 		metaCopy := validation.DeepCopy()
 		metaCopy.Status.ObservedGeneration = validation.Generation
-		setValidationCondition(&metaCopy.Status.Conditions, validation.Generation, metav1.ConditionFalse, "CollectorNotFound", fmt.Sprintf("Referenced collector %q not found", sourceName))
+		metaCopy.Status.RunID = runID
+		setValidationCondition(
+			&metaCopy.Status.Conditions,
+			validation.Generation,
+			metav1.ConditionFalse,
+			"CollectorNotFound",
+			fmt.Sprintf("Referenced collector %q not found", sourceName),
+		)
 		if statusErr := r.Status().Update(ctx, metaCopy); statusErr != nil {
 			return ContinueWithError(statusErr)
 		}
@@ -62,8 +70,15 @@ func (r *TelemetryValidationReconciler) reconcileShadowCollector(
 		metaCopy.Status.ValidatorEndpoint = resolvedValidatorEndpoint
 		metaCopy.Status.ValidatorIngressPort = validatorIngressPortStatus
 		metaCopy.Status.ObservedGeneration = validation.Generation
+		metaCopy.Status.RunID = runID
 		metaCopy.Status.ActiveSignals = activeSignals(validation.Spec.Signals)
-		setValidationCondition(&metaCopy.Status.Conditions, validation.Generation, metav1.ConditionFalse, "Disabled", "Telemetry validation shadow collector is disabled")
+		setValidationCondition(
+			&metaCopy.Status.Conditions,
+			validation.Generation,
+			metav1.ConditionFalse,
+			"Disabled",
+			"Telemetry validation shadow collector is disabled",
+		)
 		if err := r.Status().Update(ctx, metaCopy); err != nil {
 			return ContinueWithError(err)
 		}
@@ -90,7 +105,8 @@ func (r *TelemetryValidationReconciler) reconcileShadowCollector(
 			"hub.mydecisive.ai/shadow":  "true",
 		})
 		shadow.Annotations = mergeMaps(source.Annotations, map[string]string{
-			"hub.mydecisive.ai/shadow": "true",
+			"hub.mydecisive.ai/shadow":            "true",
+			telemetryValidationRunIDAnnotationKey: runID,
 		})
 
 		spec := *source.Spec.DeepCopy()
@@ -119,8 +135,15 @@ func (r *TelemetryValidationReconciler) reconcileShadowCollector(
 	metaCopy.Status.ValidatorEndpoint = resolvedValidatorEndpoint
 	metaCopy.Status.ValidatorIngressPort = validatorIngressPortStatus
 	metaCopy.Status.ObservedGeneration = validation.Generation
+	metaCopy.Status.RunID = runID
 	metaCopy.Status.ActiveSignals = activeSignals(validation.Spec.Signals)
-	setValidationCondition(&metaCopy.Status.Conditions, validation.Generation, metav1.ConditionTrue, "Ready", "Telemetry validation shadow collector is configured")
+	setValidationCondition(
+		&metaCopy.Status.Conditions,
+		validation.Generation,
+		metav1.ConditionTrue,
+		"Ready",
+		"Telemetry validation shadow collector is configured",
+	)
 	if err := r.Status().Update(ctx, metaCopy); err != nil {
 		return ContinueWithError(err)
 	}

--- a/internal/controller/telemetryvalidation_validator.go
+++ b/internal/controller/telemetryvalidation_validator.go
@@ -25,6 +25,7 @@ import (
 func (r *TelemetryValidationReconciler) reconcileValidator(
 	ctx context.Context,
 	validation *hubv1.TelemetryValidation,
+	runID string,
 ) (string, string, string, int32, error) {
 	if !validation.Spec.Enabled {
 		if err := r.deleteManagedValidatorResources(ctx, validation); err != nil {
@@ -60,6 +61,9 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 			telemetryValidationLabelKey: validation.Name,
 			"hub.mydecisive.ai/role":    telemetryValidationRoleValidator,
 		}
+		cfgMap.Annotations = map[string]string{
+			telemetryValidationRunIDAnnotationKey: runID,
+		}
 		cfgMap.Data = map[string]string{
 			"rules.yaml":         validatorRulesYAML,
 			"field-mapping.yaml": validatorFieldMappingYAML,
@@ -84,6 +88,9 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 			LabelManagedByMdaiKey:       LabelManagedByMdaiValue,
 			telemetryValidationLabelKey: validation.Name,
 			"hub.mydecisive.ai/role":    telemetryValidationRoleValidator,
+		}
+		service.Annotations = map[string]string{
+			telemetryValidationRunIDAnnotationKey: runID,
 		}
 		service.Spec = corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -124,11 +131,15 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 			return err
 		}
 
-		mdaiConnectionSourceLabel := prometheusv1.LabelName("__meta_kubernetes_service_label_hub_mydecisive_ai_telemetry_validation")
+		mdaiConnectionSourceLabel := prometheusv1.LabelName(telemetryValidationPrometheusSourceLabel)
+		runIDSourceLabel := prometheusv1.LabelName(telemetryValidationRunIDPrometheusSource)
 		monitor.Labels = map[string]string{
 			LabelManagedByMdaiKey:       LabelManagedByMdaiValue,
 			telemetryValidationLabelKey: validation.Name,
 			"hub.mydecisive.ai/role":    telemetryValidationRoleValidator,
+		}
+		monitor.Annotations = map[string]string{
+			telemetryValidationRunIDAnnotationKey: runID,
 		}
 		monitor.Spec = prometheusv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
@@ -149,6 +160,11 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 						{
 							SourceLabels: []prometheusv1.LabelName{mdaiConnectionSourceLabel},
 							TargetLabel:  "mdai_connection",
+							Action:       "replace",
+						},
+						{
+							SourceLabels: []prometheusv1.LabelName{runIDSourceLabel},
+							TargetLabel:  telemetryValidationRunIDMetricLabel,
 							Action:       "replace",
 						},
 					},
@@ -179,6 +195,9 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 			"app.kubernetes.io/instance": validation.Name,
 		}
 		deployment.Labels = labels
+		deployment.Annotations = map[string]string{
+			telemetryValidationRunIDAnnotationKey: runID,
+		}
 		deployment.Spec = appsv1.DeploymentSpec{
 			Replicas: &validatorReplicas,
 			Selector: &metav1.LabelSelector{
@@ -190,6 +209,9 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						telemetryValidationRunIDAnnotationKey: runID,
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -250,10 +272,19 @@ func (r *TelemetryValidationReconciler) reconcileValidator(
 	}
 
 	//nolint:revive // in-cluster validator endpoint is HTTP by design.
-	return validatorName, validatorServiceName, fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", validatorServiceName, validation.Namespace, validatorPort), validatorIngressPort, nil
+	validatorEndpoint := fmt.Sprintf(
+		"http://%s.%s.svc.cluster.local:%d",
+		validatorServiceName,
+		validation.Namespace,
+		validatorPort,
+	)
+	return validatorName, validatorServiceName, validatorEndpoint, validatorIngressPort, nil
 }
 
-func (r *TelemetryValidationReconciler) deleteManagedValidatorResources(ctx context.Context, validation *hubv1.TelemetryValidation) error {
+func (r *TelemetryValidationReconciler) deleteManagedValidatorResources(
+	ctx context.Context,
+	validation *hubv1.TelemetryValidation,
+) error {
 	name := validatorNameForTV(validation.Name)
 	configName := validatorConfigMapNameForTV(validation.Name)
 	monitorName := validatorMetricsMonitorNameForTV(validation.Name)
@@ -319,7 +350,10 @@ func resolveValidatorConfigYAMLs(validation *hubv1.TelemetryValidation) (string,
 	return rulesYAML, fieldMappingYAML
 }
 
-func (r *TelemetryValidationReconciler) resolveValidatorIngressPorts(ctx context.Context, validation *hubv1.TelemetryValidation) (int32, []int32, error) {
+func (r *TelemetryValidationReconciler) resolveValidatorIngressPorts(
+	ctx context.Context,
+	validation *hubv1.TelemetryValidation,
+) (int32, []int32, error) {
 	sourceName := strings.TrimSpace(validation.Spec.CollectorRef.Name)
 	if sourceName == "" {
 		return defaultValidatorReceiverPort, []int32{defaultValidatorReceiverPort}, nil

--- a/internal/controller/telemetryvalidation_validator_lifecycle_test.go
+++ b/internal/controller/telemetryvalidation_validator_lifecycle_test.go
@@ -78,7 +78,7 @@ func TestReconcileValidatorLifecycle(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tv, collector).Build()
 	r := &TelemetryValidationReconciler{Client: c, Scheme: scheme}
 
-	validatorName, validatorService, validatorEndpoint, _, err := r.reconcileValidator(context.Background(), tv)
+	validatorName, validatorService, validatorEndpoint, _, err := r.reconcileValidator(context.Background(), tv, "run-123")
 	require.NoError(t, err)
 	assert.Equal(t, "sample-fidelity-validator", validatorName)
 	assert.Equal(t, "sample-fidelity-validator", validatorService)
@@ -88,10 +88,12 @@ func TestReconcileValidatorLifecycle(t *testing.T) {
 	assertObjectExists(t, c, cfg, types.NamespacedName{Name: "sample-fidelity-validator-config", Namespace: "mdai"})
 	assert.Equal(t, telemetryValidationRoleValidator, cfg.Labels["hub.mydecisive.ai/role"])
 	assert.Equal(t, "sample", cfg.Labels[telemetryValidationLabelKey])
+	assert.Equal(t, "run-123", cfg.Annotations[telemetryValidationRunIDAnnotationKey])
 	svc := &corev1.Service{}
 	assertObjectExists(t, c, svc, types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"})
 	assert.Equal(t, telemetryValidationRoleValidator, svc.Labels["hub.mydecisive.ai/role"])
 	assert.Equal(t, "sample", svc.Labels[telemetryValidationLabelKey])
+	assert.Equal(t, "run-123", svc.Annotations[telemetryValidationRunIDAnnotationKey])
 	assertServicePort(t, svc.Spec.Ports, "receiver-18126", 18126)
 	assertServicePort(t, svc.Spec.Ports, "receiver-4317", 4317)
 	assertServicePort(t, svc.Spec.Ports, "exporter-intake", 19081)
@@ -104,10 +106,22 @@ func TestReconcileValidatorLifecycle(t *testing.T) {
 	assert.Equal(t, otelMetricsName, monitor.Spec.Endpoints[0].Port)
 	assert.Equal(t, "/metrics", monitor.Spec.Endpoints[0].Path)
 	assert.True(t, monitor.Spec.Endpoints[0].HonorLabels)
-	require.Len(t, monitor.Spec.Endpoints[0].RelabelConfigs, 1)
+	assert.Equal(t, "run-123", monitor.Annotations[telemetryValidationRunIDAnnotationKey])
+	require.Len(t, monitor.Spec.Endpoints[0].RelabelConfigs, 2)
 	assert.Equal(t, "mdai_connection", monitor.Spec.Endpoints[0].RelabelConfigs[0].TargetLabel)
 	assert.Equal(t, "replace", monitor.Spec.Endpoints[0].RelabelConfigs[0].Action)
-	assert.Equal(t, []prometheusv1.LabelName{"__meta_kubernetes_service_label_hub_mydecisive_ai_telemetry_validation"}, monitor.Spec.Endpoints[0].RelabelConfigs[0].SourceLabels)
+	assert.Equal(
+		t,
+		[]prometheusv1.LabelName{telemetryValidationPrometheusSourceLabel},
+		monitor.Spec.Endpoints[0].RelabelConfigs[0].SourceLabels,
+	)
+	assert.Equal(t, telemetryValidationRunIDMetricLabel, monitor.Spec.Endpoints[0].RelabelConfigs[1].TargetLabel)
+	assert.Equal(t, "replace", monitor.Spec.Endpoints[0].RelabelConfigs[1].Action)
+	assert.Equal(
+		t,
+		[]prometheusv1.LabelName{telemetryValidationRunIDPrometheusSource},
+		monitor.Spec.Endpoints[0].RelabelConfigs[1].SourceLabels,
+	)
 	assert.Equal(t, []string{"mdai"}, monitor.Spec.NamespaceSelector.MatchNames)
 	assert.Equal(t, map[string]string{
 		telemetryValidationLabelKey: "sample",
@@ -117,20 +131,42 @@ func TestReconcileValidatorLifecycle(t *testing.T) {
 	assertObjectExists(t, c, deploy, types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"})
 	assert.Equal(t, telemetryValidationRoleValidator, deploy.Labels["hub.mydecisive.ai/role"])
 	assert.Equal(t, "sample", deploy.Labels[telemetryValidationLabelKey])
+	assert.Equal(t, "run-123", deploy.Annotations[telemetryValidationRunIDAnnotationKey])
+	assert.Equal(t, "run-123", deploy.Spec.Template.Annotations[telemetryValidationRunIDAnnotationKey])
 	assertDeploymentContainerPort(t, deploy, otelMetricsName, otelMetricsPort)
 	assertDeploymentEnvVar(t, deploy, "MDAI_DATADOG_AGENT_INGEST_ADDR", ":18126")
 
 	tv.Spec.Enabled = false
-	validatorName, validatorService, validatorEndpoint, _, err = r.reconcileValidator(context.Background(), tv)
+	validatorName, validatorService, validatorEndpoint, _, err = r.reconcileValidator(context.Background(), tv, "run-123")
 	require.NoError(t, err)
 	assert.Empty(t, validatorName)
 	assert.Empty(t, validatorService)
 	assert.Empty(t, validatorEndpoint)
 
-	assertObjectNotFound(t, c, &corev1.ConfigMap{}, types.NamespacedName{Name: "sample-fidelity-validator-config", Namespace: "mdai"})
-	assertObjectNotFound(t, c, &corev1.Service{}, types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"})
-	assertObjectNotFound(t, c, &prometheusv1.ServiceMonitor{}, types.NamespacedName{Name: "sample-fidelity-validator-metrics", Namespace: "mdai"})
-	assertObjectNotFound(t, c, &appsv1.Deployment{}, types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"})
+	assertObjectNotFound(
+		t,
+		c,
+		&corev1.ConfigMap{},
+		types.NamespacedName{Name: "sample-fidelity-validator-config", Namespace: "mdai"},
+	)
+	assertObjectNotFound(
+		t,
+		c,
+		&corev1.Service{},
+		types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"},
+	)
+	assertObjectNotFound(
+		t,
+		c,
+		&prometheusv1.ServiceMonitor{},
+		types.NamespacedName{Name: "sample-fidelity-validator-metrics", Namespace: "mdai"},
+	)
+	assertObjectNotFound(
+		t,
+		c,
+		&appsv1.Deployment{},
+		types.NamespacedName{Name: "sample-fidelity-validator", Namespace: "mdai"},
+	)
 }
 
 func TestReconcileValidatorLifecycleUsesEmbeddedDefaultsWhenValidatorConfigEmpty(t *testing.T) {
@@ -175,7 +211,7 @@ func TestReconcileValidatorLifecycleUsesEmbeddedDefaultsWhenValidatorConfigEmpty
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tv, collector).Build()
 	r := &TelemetryValidationReconciler{Client: c, Scheme: scheme}
 
-	_, _, validatorEndpoint, _, err := r.reconcileValidator(context.Background(), tv) //nolint:dogsled
+	_, _, validatorEndpoint, _, err := r.reconcileValidator(context.Background(), tv, "run-123") //nolint:dogsled
 	require.NoError(t, err)
 	assert.NotEmpty(t, validatorEndpoint)
 
@@ -283,12 +319,16 @@ func TestReconcileCreatesShadowCollectorLabels(t *testing.T) {
 
 	shadow := &otelv1beta1.OpenTelemetryCollector{}
 	assertObjectExists(t, c, shadow, types.NamespacedName{Name: shadowCollectorName("gateway"), Namespace: "mdai"})
+	updated := &hubv1.TelemetryValidation{}
+	assertObjectExists(t, c, updated, types.NamespacedName{Name: "sample", Namespace: "mdai"})
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, updated.Status.RunID)
 	assert.Equal(t, telemetryValidationRoleShadow, shadow.Labels["hub.mydecisive.ai/role"])
 	assert.Equal(t, "sample", shadow.Labels[telemetryValidationLabelKey])
 	assert.Equal(t, "true", shadow.Labels["hub.mydecisive.ai/shadow"])
 	assert.Equal(t, "gateway", shadow.Labels["hub.mydecisive.ai/source"])
 	assert.Equal(t, "kept", shadow.Labels["existing-label"])
 	assert.Equal(t, "true", shadow.Annotations["hub.mydecisive.ai/shadow"])
+	assert.Equal(t, updated.Status.RunID, shadow.Annotations[telemetryValidationRunIDAnnotationKey])
 	assert.Equal(t, "kept", shadow.Annotations["existing-annotation"])
 }
 


### PR DESCRIPTION
<!--
For Work In Progress pull requests, please use the Draft PR feature.

For a timely review/response, please avoid force-pushing additional
commits if your PR already received reviews or comments.

Before submitting a pull request, please ensure you've done the following:
- Create small PRs. In most cases this will be possible.
- Provide tests for your changes.
- Add/update relevant documentation(s).
- Fill out the pull request template.
- Ensure your PR title follow the guideline described in: 
  https://github.com/MyDecisive/changelogs?tab=readme-ov-file#pull-request-title
-->

## Description
add `runID` to TelemetryValidation CRD; if not provided, one is generated and used as an annotation on the pod and as label on generated metrics when scraped by Prometheus.

```Annotations:      [hub.mydecisive.ai/telemetry-validation-run-id](http://hub.mydecisive.ai/telemetry-validation-run-id): test-run-id```
```
mdai_fidelity_attribute_checks_total{attribute="ddsource",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="fail",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_attribute_checks_total{attribute="hostname",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="fail",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_attribute_checks_total{attribute="message",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_attribute_checks_total{attribute="service",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_attribute_checks_total{attribute="status",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_attribute_checks_total{attribute="timestamp",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="fail",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_payloads_received_total{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",service="sample-fidelity-validator",signal="logs",source="exporter",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 2 1777476023521
mdai_fidelity_payloads_received_total{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",service="sample-fidelity-validator",signal="logs",source="receiver",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_payloads_received_total{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",service="sample-fidelity-validator",signal="unknown",source="exporter",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 2 1777476023521
mdai_fidelity_pending_payloads{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",service="sample-fidelity-validator",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 0 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="ddsource",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="hostname",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="message",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="service",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="status",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_attribute_checks_total{attribute="timestamp",container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_required_signal_checks_total{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="pass",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
mdai_fidelity_signal_checks_total{container="validator",endpoint="otel-metrics",instance="10.244.0.30:8888",job="sample-fidelity-validator",mdai_connection="sample",namespace="mdai",pod="sample-fidelity-validator-5d4f6d8447-k6hfj",result="fail",service="sample-fidelity-validator",signal="logs",telemetry_validation_run_id="test-run-id",cluster="mdai-cluster",prometheus="mdai/kube-prometheus-stack-prometheus",prometheus_replica="prometheus-kube-prometheus-stack-prometheus-0"} 1 1777476023521
```
<!--
Please describe the changes you made in this pull request.

If applicable, please feel free to include screenshots to make it
easier for reviewers understand your pull request. 

If there are any relevant documentations that help explain your pull
request, please feel free to include them as well.
-->

- ENG-1284<!--REPLACE THIS WITH JIRA TICKET NUMBER-->

## What type of PR is this? (only check one)
<!--
If you need to check more than one (except if the other type is `doc`, 
always do add more doc) to properly capture the PR type, please 
consider splitting up your PR.

If you selected Other, please ensure the type you provided
is one of the valid types outlined in
https://github.com/MyDecisive/changelogs?tab=readme-ov-file#type
-->

- [x] Feature (`feat`)
- [ ] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [x] No
- [ ] Yes, and this is why: 
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

<!--
Uncomment this section if needed:
## Updated [`mdai-labs`](https://github.com/MyDecisive/mdai-labs) to reflect changes done in this PR?
- [ ] Yes
- [ ] N/A
- [ ] I need help, please elaborate: 
-->
